### PR TITLE
Start profiling via func call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ To enable memory profiling, modify your main method like this:
 		// add handlers to help us track memory usage - they don't track memory until they're told to
 		profiler.AddMemoryProfilingHandlers()
 
+		// Uncomment if you want to start profiling automatically
+		// profiler.StartProfiling()
+
 		// listen on port 6060 (pick a port)
 		http.ListenAndServe(":6060", nil)
 	}

--- a/web_endpoints.go
+++ b/web_endpoints.go
@@ -101,16 +101,26 @@ func AddMemoryProfilingHandlers() {
 	http.HandleFunc("/profiler/stop", StopProfilingHandler)
 }
 
+// StartProfiling is a function to start profiling automatically without web button
+func StartProfiling() {
+    commandChannel <- startTracking
+}
+
+// StopProfiling is a function to stop profiling automatically without web button
+func StopProfiling() {
+    commandChannel <- stopTracking
+}
+
 // StartProfilingHandler is a HTTP Handler to start memory profiling, if we're not already
 func StartProfilingHandler(w http.ResponseWriter, r *http.Request) {
-	commandChannel <- startTracking
+	StartProfiling()
 	time.Sleep(500 * time.Millisecond)
 	http.Redirect(w, r, "/profiler/info.html", http.StatusTemporaryRedirect)
 }
 
 // StopProfilingHandler is a HTTP Handler to stop memory profiling, if we're profiling
 func StopProfilingHandler(w http.ResponseWriter, r *http.Request) {
-	commandChannel <- stopTracking
+	StopProfiling()
 	time.Sleep(500 * time.Millisecond)
 	http.Redirect(w, r, "/profiler/info.html", http.StatusTemporaryRedirect)
 }


### PR DESCRIPTION
Sometimes it's good to start profiling automatically. For example, I configured my app to start it only if I started service with "-p=localhost:6060". So if I am sure I can start it automatically.
